### PR TITLE
Fix regression from #16: unable to use crate if left while using one

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -323,12 +323,12 @@ minetest.register_node("towercrane:mast_ctrl_off", {
 })
 
 minetest.register_on_joinplayer(function(player)
-	-- To recover from a crash, this must be done unconditionally
-	reset_operator_privs(player)
 	local pos = get_my_crane_pos(player)
 	if pos then
 		stop_crane(pos, player)
 	end
+	-- To recover from a crash, this must be done unconditionally
+	reset_operator_privs(player)
 end)
 
 minetest.register_on_leaveplayer(function(player)


### PR DESCRIPTION
A player reported not being able to turn off their crate. After investigation, a wrong order of code execution caused the issue.

In the code of #16, the attempt to turn off crates is done after resetting the player status. However, resetting also removes the association between the player and the crate. So in this PR, the two code blocks are swapped.